### PR TITLE
fix(niri-session)!: no longer import all environment variables into dbus/systemd

### DIFF
--- a/resources/niri-session
+++ b/resources/niri-session
@@ -20,17 +20,6 @@ fi
 # Reset failed state of all user units.
 systemctl --user reset-failed
 
-# Import the login manager environment.
-systemctl --user import-environment
-
-# DBus activation environment is independent from systemd. While most of
-# dbus-activated services are already using `SystemdService` directive, some
-# still don't and thus we should set the dbus environment with a separate
-# command.
-if hash dbus-update-activation-environment 2>/dev/null; then
-    dbus-update-activation-environment --all
-fi
-
 # Start niri and wait for it to terminate.
 systemctl --user --wait start niri.service
 


### PR DESCRIPTION
fixes #254

I did some testing and can confirm that the contents of my environment variables and those in my user service manager were as expected on my machine

But note that I'm not yet using niri as my primary desktop, so it's possible/probable that my testing doesn't cover something someone else would notice and miss dearly